### PR TITLE
Fix duplicate mobile logo

### DIFF
--- a/src/components/landing/navbar.tsx
+++ b/src/components/landing/navbar.tsx
@@ -130,7 +130,10 @@ export const Navbar = () => {
       </div>
 
       {/* <!-- Desktop Logo --> */}
-      <Link href="/" className="font-bold text-lg flex items-center lg:block">
+      <Link
+        href="/"
+        className="font-bold text-lg flex items-center hidden lg:block"
+      >
         <Book
           className={`${BRAND_COLORS.primary.bg} ${BRAND_COLORS.primary.border} border-secondary from-brand-primary via-brand-primary/70 to-brand-primary rounded-lg w-7 h-7 mr-2 border text-white`}
         />


### PR DESCRIPTION
## Summary
- hide desktop logo on mobile

## Testing
- `npm test --silent` *(fails: 17 failed, 607 passed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687a45d36c1483308161d28fbf23dd75